### PR TITLE
Fixed crucial typo in Camera's parameterized constructor

### DIFF
--- a/src/elements/Camera.java
+++ b/src/elements/Camera.java
@@ -23,7 +23,7 @@ public class Camera {
 		_p0 = p0;
 		_vUp = vUp;
 		_vTo = vTo;
-		_vRight = _vRight;
+		_vRight = vRight;
 	}
 	
 	//Copy Constructor


### PR DESCRIPTION
 from `_vRight = _vRight` to `_vRight = vRight`